### PR TITLE
apscheduler 3.10.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "APScheduler" %}
-{% set version = "3.9.0" %}
-{% set hash_val = "c7a0935b4e2509393615107d9d031114b7fa4f834619b883a06ed1641cd71a51" %}
+{% set version = "3.10.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,26 +7,26 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ hash_val }}
+  sha256: e6df071b27d9be898e486bc7940a7be50b4af2e9da7c08f0744a96d4bd4cef4a
 
 build:
-  skip: True #[py<37]
+  skip: True  # [py<36]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - python
     - pip
     - setuptools
-    - setuptools_scm
+    - setuptools-scm
     - wheel
   run:
     - python
-    - setuptools >=0.7
     - six >=1.4.0
     - pytz
     - tzlocal >=2.0,!=3.*
+    - importlib-metadata >=3.6.0  # [py<38]
 
 test:
   imports:
@@ -42,13 +41,12 @@ test:
     - pip
   commands:
     - pip check
-    
 
 about:
   home: https://github.com/agronholm/apscheduler
   description: |
     Advanced Python Scheduler (APScheduler) is a Python library that lets you schedule 
-    your Python code to be executed later, either just once or periodically. 
+    your Python code to be executed later, either just once or periodically.
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,12 @@ requirements:
     - pytz
     - tzlocal >=2.0,!=3.*
     - importlib-metadata >=3.6.0  # [py<38]
+  run_constrained:
+    - pymongo >= 3.0
+    - redis >= 3.0
+    - rethinkdb >= 2.4.0
+    - sqlalchemy >= 1.4
+    - tornado >= 4.3
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5118](https://anaconda.atlassian.net/browse/PKG-5118)
- release-notes: https://github.com/agronholm/apscheduler/releases
- release-diff: https://github.com/agronholm/apscheduler/compare/3.9.0...3.10.4
- license: https://github.com/agronholm/apscheduler/blob/master/LICENSE.txt
- requirements-tagged:
  - https://github.com/agronholm/apscheduler/blob/3.10.4/setup.py

### Explanation of changes:

- Clean up the recipe
- Add importlib-metadata to run and remove setuptools from runtime

[PKG-5118]: https://anaconda.atlassian.net/browse/PKG-5118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ